### PR TITLE
Added in test Target Name in classname and removed () from name

### DIFF
--- a/lib/trainer/options.rb
+++ b/lib/trainer/options.rb
@@ -33,7 +33,13 @@ module Trainer
                                      env_name: "TRAINER_FAIL_BUILD",
                                      description: "Should this step stop the build if the tests fail? Set this to false if you're handling this with a test reporter",
                                      is_string: false,
-                                     default_value: true)
+                                     default_value: true),
+        FastlaneCore::ConfigItem.new(key: :xcpretty_naming,
+									 short_option: "-x",
+									 env_name: "TRAINER_XCPRETTY_NAMING",
+                                     description: "Produces class name and test name identical to xcpretty naming in junit file",
+									 is_string: false,
+                                     default_value: false)
       ]
     end
   end

--- a/lib/trainer/options.rb
+++ b/lib/trainer/options.rb
@@ -35,10 +35,10 @@ module Trainer
                                      is_string: false,
                                      default_value: true),
         FastlaneCore::ConfigItem.new(key: :xcpretty_naming,
-                   short_option: "-x",
-                   env_name: "TRAINER_XCPRETTY_NAMING",
+                                     short_option: "-x",
+                                     env_name: "TRAINER_XCPRETTY_NAMING",
                                      description: "Produces class name and test name identical to xcpretty naming in junit file",
-                   is_string: false,
+                                     is_string: false,
                                      default_value: false)
       ]
     end

--- a/lib/trainer/options.rb
+++ b/lib/trainer/options.rb
@@ -35,10 +35,10 @@ module Trainer
                                      is_string: false,
                                      default_value: true),
         FastlaneCore::ConfigItem.new(key: :xcpretty_naming,
-									 short_option: "-x",
-									 env_name: "TRAINER_XCPRETTY_NAMING",
+                   short_option: "-x",
+                   env_name: "TRAINER_XCPRETTY_NAMING",
                                      description: "Produces class name and test name identical to xcpretty naming in junit file",
-									 is_string: false,
+                   is_string: false,
                                      default_value: false)
       ]
     end

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -118,8 +118,8 @@ module Trainer
           tests: unfold_tests(testable_summary["Tests"]).collect do |current_test|
             current_row = {
               identifier: current_test["TestIdentifier"],
-              test_group: current_test["TestIdentifier"].split("/")[0..-2].join("."),
-              name: current_test["TestName"],
+			  test_group: testable_summary["TargetName"] + "." + current_test["TestIdentifier"].split("/")[0..-2].join("."),
+			  name: current_test["TestName"][0..-3],
               object_class: current_test["TestObjectClass"],
               status: current_test["TestStatus"],
               guid: current_test["TestSummaryGUID"],

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -116,17 +116,17 @@ module Trainer
           test_name: testable_summary["TestName"],
           duration: testable_summary["Tests"].map { |current_test| current_test["Duration"] }.inject(:+),
           tests: unfold_tests(testable_summary["Tests"]).collect do |current_test|
-			if xcpretty_naming
-				test_group = testable_summary["TargetName"] + "." + current_test["TestIdentifier"].split("/")[0..-2].join(".")
-				test_name = current_test["TestName"][0..-3]
-			else
-				test_group = current_test["TestIdentifier"].split("/")[0..-2].join(".")
-				test_name = current_test["TestName"]
-			end
+            if xcpretty_naming
+              test_group = testable_summary["TargetName"] + "." + current_test["TestIdentifier"].split("/")[0..-2].join(".")
+              test_name = current_test["TestName"][0..-3]
+            else
+              test_group = current_test["TestIdentifier"].split("/")[0..-2].join(".")
+              test_name = current_test["TestName"]
+            end
             current_row = {
               identifier: current_test["TestIdentifier"],
-			  test_group: test_group,
-			  name: test_name,
+                 test_group: test_group,
+                 name: test_name,
               object_class: current_test["TestObjectClass"],
               status: current_test["TestStatus"],
               guid: current_test["TestSummaryGUID"],

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -107,6 +107,19 @@ module Trainer
       return tests
     end
 
+    # Returns the test group and test name from the passed summary and test
+    # Pass xcpretty_naming = true to get the test naming aligned with xcpretty
+    def test_group_and_name(testable_summary, test, xcpretty_naming)
+      if xcpretty_naming
+        group = testable_summary["TargetName"] + "." + test["TestIdentifier"].split("/")[0..-2].join(".")
+        name = test["TestName"][0..-3]
+      else
+        group = test["TestIdentifier"].split("/")[0..-2].join(".")
+        name = test["TestName"]
+      end
+      return group, name
+    end
+
     # Convert the Hashes and Arrays in something more useful
     def parse_content(xcpretty_naming)
       self.data = self.raw_json["TestableSummaries"].collect do |testable_summary|
@@ -116,13 +129,7 @@ module Trainer
           test_name: testable_summary["TestName"],
           duration: testable_summary["Tests"].map { |current_test| current_test["Duration"] }.inject(:+),
           tests: unfold_tests(testable_summary["Tests"]).collect do |current_test|
-            if xcpretty_naming
-              test_group = testable_summary["TargetName"] + "." + current_test["TestIdentifier"].split("/")[0..-2].join(".")
-              test_name = current_test["TestName"][0..-3]
-            else
-              test_group = current_test["TestIdentifier"].split("/")[0..-2].join(".")
-              test_name = current_test["TestName"]
-            end
+            test_group, test_name = test_group_and_name(testable_summary, current_test, xcpretty_naming)
             current_row = {
               identifier: current_test["TestIdentifier"],
                  test_group: test_group,

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -46,7 +46,7 @@ module Trainer
       return_hash
     end
 
-    def initialize(path, config)
+    def initialize(path, config = {})
       path = File.expand_path(path)
       UI.user_error!("File not found at path '#{path}'") unless File.exist?(path)
 

--- a/spec/fixtures/Valid1-x.junit
+++ b/spec/fixtures/Valid1-x.junit
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="1">
+    <testsuite name="Unit" tests="3" failures="1" time="0.4">
+        <testcase classname="Unit.Unit" name="testExample" time="0.1">
+        </testcase>
+        <testcase classname="Unit.Unit" name="testExample2" time="0.1">
+            <failure message="XCTAssertTrue failed -  (/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19)">
+            </failure>
+        </testcase>
+        <testcase classname="Unit.Unit" name="testPerformanceExample" time="0.2">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/spec/fixtures/Valid2-x.junit
+++ b/spec/fixtures/Valid2-x.junit
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="0">
+    <testsuite name="Unit" tests="3" failures="0" time="0.4">
+        <testcase classname="Unit.Unit" name="testExample" time="0.1">
+        </testcase>
+        <testcase classname="Unit.Unit" name="testExample2" time="0.1">
+        </testcase>
+        <testcase classname="Unit.Unit" name="testPerformanceExample" time="0.2">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/spec/junit_generator_spec.rb
+++ b/spec/junit_generator_spec.rb
@@ -6,9 +6,21 @@ describe Trainer do
       expect(tp.to_junit).to eq(junit)
     end
 
+    it "works for a valid .plist file and xcpretty naming" do
+      tp = Trainer::TestParser.new("spec/fixtures/Valid1.plist", { xcpretty_naming: true })
+      junit = File.read("spec/fixtures/Valid1-x.junit")
+      expect(tp.to_junit).to eq(junit)
+    end
+
     it "works for a with all tests passing" do
       tp = Trainer::TestParser.new("spec/fixtures/Valid2.plist")
       junit = File.read("spec/fixtures/Valid2.junit")
+      expect(tp.to_junit).to eq(junit)
+    end
+
+    it "works for a with all tests passing and xcpretty naming" do
+      tp = Trainer::TestParser.new("spec/fixtures/Valid2.plist", { xcpretty_naming: true })
+      junit = File.read("spec/fixtures/Valid2-x.junit")
       expect(tp.to_junit).to eq(junit)
     end
   end


### PR DESCRIPTION
Although xcpretty and trainer parse different files to produce the Junit output, the content of the Junit file produced should be identical.

The testcase `classname` and `name` are used to identify uniquely a test across different test runs, for example in third party Tests managers like Xray for JIRA.

In the scenario of transition of xcpretty to trainer, it is required that the tests can be identified in a test run before the transition and a run after the transition.

In the Junit produced by xcpretty : 
- the test classname is the test method classname prefixed by the test target in Xcode
- the test name is the name of the test method in the code, without `()`
In the Junit produced by trainer : 
- the test classname is is the test method classname without prefix
- the test name is the name of the test method in the code, including `()`

This Pull Request includes changes to align the Junit test `classname` and `name` with xcpretty format.
