### PR TITLE
Quote paths that are passed to xcresulttool

### DIFF
--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -143,7 +143,7 @@ module Trainer
 
     def parse_xcresult(path)
       # Executes xcresulttool to get JSON format of the result bundle object
-      result_bundle_object_raw = execute_cmd("xcrun xcresulttool get --format json --path #{path}")
+      result_bundle_object_raw = execute_cmd("xcrun xcresulttool get --format json --path '#{path}'")
       result_bundle_object = JSON.parse(result_bundle_object_raw)
 
       # Parses JSON into ActionsInvocationRecord to find a list of all ids for ActionTestPlanRunSummaries
@@ -156,7 +156,7 @@ module Trainer
       # Maps ids into ActionTestPlanRunSummaries by executing xcresulttool to get JSON
       # containing specific information for each test summary,
       summaries = ids.map do |id|
-        raw = execute_cmd("xcrun xcresulttool get --format json --path #{path} --id #{id}")
+        raw = execute_cmd("xcrun xcresulttool get --format json --path '#{path}' --id #{id}")
         json = JSON.parse(raw)
         Trainer::XCResult::ActionTestPlanRunSummaries.new(json)
       end

--- a/lib/trainer/test_parser.rb
+++ b/lib/trainer/test_parser.rb
@@ -142,8 +142,11 @@ module Trainer
     end
 
     def parse_xcresult(path)
+      require 'shellwords'
+      path = Shellwords.escape(path)
+
       # Executes xcresulttool to get JSON format of the result bundle object
-      result_bundle_object_raw = execute_cmd("xcrun xcresulttool get --format json --path '#{path}'")
+      result_bundle_object_raw = execute_cmd("xcrun xcresulttool get --format json --path #{path}")
       result_bundle_object = JSON.parse(result_bundle_object_raw)
 
       # Parses JSON into ActionsInvocationRecord to find a list of all ids for ActionTestPlanRunSummaries
@@ -156,7 +159,7 @@ module Trainer
       # Maps ids into ActionTestPlanRunSummaries by executing xcresulttool to get JSON
       # containing specific information for each test summary,
       summaries = ids.map do |id|
-        raw = execute_cmd("xcrun xcresulttool get --format json --path '#{path}' --id #{id}")
+        raw = execute_cmd("xcrun xcresulttool get --format json --path #{path} --id #{id}")
         json = JSON.parse(raw)
         Trainer::XCResult::ActionTestPlanRunSummaries.new(json)
       end


### PR DESCRIPTION
Fixes errors when running in a path that has spaces in it.

Thanks for the Xcode 11 update!